### PR TITLE
Feature/支持阿里云oss内网上传

### DIFF
--- a/blog_system/settings.py
+++ b/blog_system/settings.py
@@ -160,9 +160,14 @@ DEPLOY_URL = os.path.join(WH_RootUrl, WH_Deploys["url"], "<str:srvtype>/")
 DEPLOY_SYS = {}
 for subSys in WH_Deploys["subSys"]:
     DEPLOY_SYS[subSys["type"]] = subSys
+# OSS
+WebHooks = config["WebHooks"]
+WH_RootUrl = WebHooks["rootUrl"]
+WH_Secret = WebHooks["secret"]
+OSS_URL = os.path.join(config["UPLOAD2OSS"]["url"], "<str:srvtype>/")
 
 # 日志配置
-LOG_DIR = "/var/log/django"
+LOG_DIR = "../logs/django"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/blog_system/settings.py
+++ b/blog_system/settings.py
@@ -161,10 +161,8 @@ DEPLOY_SYS = {}
 for subSys in WH_Deploys["subSys"]:
     DEPLOY_SYS[subSys["type"]] = subSys
 # OSS
-WebHooks = config["WebHooks"]
-WH_RootUrl = WebHooks["rootUrl"]
-WH_Secret = WebHooks["secret"]
-OSS_URL = os.path.join(config["UPLOAD2OSS"]["url"], "<str:srvtype>/")
+OSS_CFG = config["UPLOAD2OSS"]
+OSS_URL = os.path.join("", OSS_CFG["url"])
 
 # 日志配置
 LOG_DIR = "../logs/django"

--- a/blog_system/urls.py
+++ b/blog_system/urls.py
@@ -24,7 +24,8 @@ from django.views.static import serve
 
 # noinf的【urls.py】设置,使输入IP就能访问首页
 from noinf import views
-from noinf.upload import upload_image
+from noinf.upload import upload_image, oss_upload
+
 
 """
 urlpatterns = [
@@ -49,4 +50,5 @@ urlpatterns = [
     url(r"^static/(?P<path>.*)$", static.serve, {"document_root": settings.STATIC_ROOT}, name="static"),
     path(settings.PUBLISH_URL.lstrip("/"), views.hookPublish),
     path(settings.DEPLOY_URL.lstrip("/"), views.deployDeal),
+    path(settings.OSS_URL.lstrip("/"), oss_upload),
 ]

--- a/configure/config_template
+++ b/configure/config_template
@@ -7,37 +7,45 @@
     "[::1]"
   ],
   "db_config": {
-    "NAME": "xxx",  
+    "NAME": "xxx",
     "USER": "xxx",
     "PASSWORD": "xxx",
     "HOST": "",
     "PORT": ""
   },
-  "WebHooks":{
-    "secret":"aaa",
-    "rootUrl":"xxxx/",
-    "deploy":{
-      "url":"deploy/",
-      "subSys":[
+  "WebHooks": {
+    "secret": "aaa",
+    "rootUrl": "xxxx/",
+    "deploy": {
+      "url": "deploy/",
+      "subSys": [
         {
-          "desc":"服务部署",
-          "type":"server",  //这里的type是标识服务类型，同时是URL的子路径，如 /rootUrl/deploy/server/
-          "sender":"github",
-          "contentPath":"dddddddddddd"
+          "desc": "服务部署",
+          "type": "server", //这里的type是标识服务类型，同时是URL的子路径，如 /rootUrl/deploy/server/
+          "sender": "github",
+          "contentPath": "dddddddddddd"
         },
         {
-          "desc":"web部署",
-          "type":"web",
-          "sender":"github",
-          "contentPath":"cccccccccccc"
+          "desc": "web部署",
+          "type": "web",
+          "sender": "github",
+          "contentPath": "cccccccccccc"
         }
       ]
     },
-    "publish":{
-        "desc":"markdown文章发布",
-        "sender":"gitee",
-        "url":"pulish/",
-        "contentPath":"dddddddddddd"
+    "publish": {
+      "desc": "markdown文章发布",
+      "sender": "gitee",
+      "url": "pulish/",
+      "contentPath": "dddddddddddd"
     }
+  },
+  "UPLOAD2OSS": {
+    "outerUrl": "xxxx/",
+    "innerUrl": "xxxx/",
+    "keyId": "",
+    "keySecret": "",
+    "endpoint": "",
+    "bucket": ""
   }
 }

--- a/configure/nginx.conf
+++ b/configure/nginx.conf
@@ -41,6 +41,12 @@ http {
         access_log  /var/log/nginx/blog_system.access.log  main;
         error_log   /var/log/nginx/blog_system.error.log;
 
+        location /oss/ {
+            proxy_pass http://固定bucket.oss内网endpoint/;
+            if ($request_method !~* GET) {
+                return 403;
+            }
+        }
         location / {
             include uwsgi_params;
             #uwsgi_pass  unix:///run/uwsgi/blogsrv.sock;

--- a/configure/nginx.conf
+++ b/configure/nginx.conf
@@ -15,6 +15,7 @@ events {
 
 
 http {
+    resolver 223.5.5.5;
     include       mime.types;
     default_type  application/octet-stream;
 
@@ -42,20 +43,27 @@ http {
         error_log   /var/log/nginx/blog_system.error.log;
 
         location /oss/ {
-            set $bucket '';
-            set $endpoint '';
-            access_by_lua '
+            resolver 223.5.5.5;
+            set $ossproxy '';
+            # must do set
+            set $remainder $1;
+            access_by_lua_block {
                 local cjson = require "cjson"
-                local file = io.open("config.json", "r")
+                # 必须绝对路径
+                local file, msg = io.open("/usr/local/openresty/nginx/conf/config", "r")
                 local content = file:read("*all")
                 local config = cjson.decode(content);
 
                 -- 设置重定向的url
-                ngx.var.bucket = config["UPLOAD2OSS"]["bucket"]
-                ngx.var.endpoint = config["UPLOAD2OSS"]["endpoint"]
-                ngx.log(ngx.ERR, "server is =========: ",server)
-            ';
-            proxy_pass http://$bucket.$endpoint/;
+                local bucket = config["UPLOAD2OSS"]["bucket"]
+                local endpoint = config["UPLOAD2OSS"]["endpoint"]
+                ngx.var.ossproxy=bucket .. "." .. endpoint
+            }
+
+            proxy_pass http://$ossproxy$remainder;
+            if ($request_method !~* GET) {
+                return 403;
+            }
             if ($request_method !~* GET) {
                 return 403;
             }

--- a/configure/nginx.conf
+++ b/configure/nginx.conf
@@ -42,7 +42,20 @@ http {
         error_log   /var/log/nginx/blog_system.error.log;
 
         location /oss/ {
-            proxy_pass http://固定bucket.oss内网endpoint/;
+            set $bucket '';
+            set $endpoint '';
+            access_by_lua '
+                local cjson = require "cjson"
+                local file = io.open("config.json", "r")
+                local content = file:read("*all")
+                local config = cjson.decode(content);
+
+                -- 设置重定向的url
+                ngx.var.bucket = config["UPLOAD2OSS"]["bucket"]
+                ngx.var.endpoint = config["UPLOAD2OSS"]["endpoint"]
+                ngx.log(ngx.ERR, "server is =========: ",server)
+            ';
+            proxy_pass http://$bucket.$endpoint/;
             if ($request_method !~* GET) {
                 return 403;
             }

--- a/configure/server_openresty.sh
+++ b/configure/server_openresty.sh
@@ -5,9 +5,10 @@ set -e
 CURDIR=$(cd "$(dirname "$0")";pwd)
 echo $CURDIR
 
-nginxconf=$CURDIR/nginx.conf
-echo $nginxconf
+cp -f $CURDIR/nginx.conf /usr/local/openresty/nginx/conf/
+cp -f $CURDIR/config /usr/local/openresty/nginx/conf/
 
+mkdir -p /var/log/nginx/
 echo "
 # Stop dance for OpenResty
 # =========================
@@ -29,9 +30,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/log/nginx/nginx.pid
-ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t -q -c $nginxconf -g 'daemon on; master_process on;' 
-ExecStart=/usr/local/openresty/nginx/sbin/nginx -c $nginxconf -g 'daemon on; master_process on;' 
-ExecReload=/usr/local/openresty/nginx/sbin/nginx -c $nginxconf -g 'daemon on; master_process on;' -s reload
+ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t -q -g 'daemon on; master_process on;' 
+ExecStart=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;' 
+ExecReload=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;' -s reload
 ExecStop=-/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /var/log/nginx/nginx.pid
 TimeoutStopSec=5
 KillMode=mixed

--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,9 @@
 #! /bin/bash
 set -x -e
 PRJDIR=$(cd "$(dirname "$0")";pwd)
-
 # nginx/openresty系统服务/usr/lib/systemd/system/openresty.service修改
 # 指定配置文件
-bash $PRJDIR/server_openresty.sh
+bash $PRJDIR/configure/server_openresty.sh
 
 # 日志切片
 # 这个实际是生成的临时配置，服务重启后丢失

--- a/noinf/upload.py
+++ b/noinf/upload.py
@@ -79,4 +79,5 @@ def oss_upload(request: HttpRequest):
     filename = file.name
 
     oss = OssOperate()
-    oss.upload(file, filename)
+    result = oss.upload(file, filename)
+    return JsonResponse(result)

--- a/noinf/upload.py
+++ b/noinf/upload.py
@@ -4,12 +4,18 @@ import os
 import uuid
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
+from django.http import HttpRequest
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from django.contrib.auth.decorators import login_required
+from oss.upload import OssOperate
 
 
+@login_required
 @csrf_exempt
-def upload_image(request, dir_name):
+@require_POST  # 限制只能是POST方法请求
+def upload_image(request: HttpRequest, dir_name):
     ##################
     #  kindeditor图片上传返回数据格式说明：
     # {"error": 1, "message": "出错信息"}
@@ -31,7 +37,6 @@ def generation_upload_dir(dir_name):
     return dir_name
 
 
-# 图片上传
 def image_upload(files, dir_name):
     bsuccess = False
     print(dir_name)
@@ -63,3 +68,15 @@ def image_upload(files, dir_name):
         return {"error": 0, "url": file_url}
 
     return {"error": 1, "message": "图片存储失败"}
+
+
+@csrf_exempt
+@require_POST  # 限制只能是POST方法请求
+def oss_upload(request: HttpRequest):
+    file = request.FILES.get("file")
+    if file is None:
+        return JsonResponse({"code": 400, "msg": "no files for upload"})
+    filename = file.name
+
+    oss = OssOperate()
+    oss.upload(file, filename)

--- a/oss/upload.py
+++ b/oss/upload.py
@@ -1,0 +1,39 @@
+import os
+import oss2 as aliyunoss
+
+from django.conf import settings
+
+OSS = settings.OSS_CFG
+
+
+class OssOperate:
+    def __init__(self):
+        # 阿里云账号AccessKey拥有所有API的访问权限，风险很高。
+        # 强烈建议您创建并使用RAM用户进行API访问或日常运维，请登录RAM控制台创建RAM用户。
+        auth = aliyunoss.Auth(OSS["keyId"], OSS["keySecret"])
+        # yourEndpoint填写Bucket所在地域对应的Endpoint。
+        # 以华东1（杭州）为例，Endpoint填写为https://oss-cn-hangzhou.aliyuncs.com。
+        # 填写Bucket名称。
+        self.bucket = aliyunoss.Bucket(auth, OSS["endpoint"], OSS["bucket"])
+
+    def upload_local_file(self, filepath, filename):
+        # 必须以二进制的方式打开文件。
+        # 填写本地文件的完整路径。如果未指定本地路径，则默认从示例程序所属项目对应本地路径中上传文件。
+        with open(filepath, "rb") as fileobj:
+            # Seek方法用于指定从第1000个字节位置开始读写。上传时会从您指定的第1000个字节位置开始上传，直到文件结束。
+            fileobj.seek(0, os.SEEK_SET)
+            # Tell方法用于返回当前位置。
+            # current = fileobj.tell()
+            result = self.upload(fileobj, filename)
+        return result
+
+    def upload(self, data, filename):
+        # 如果需要在上传文件时设置文件存储类型（x-oss-storage-class）和访问权限（x-oss-object-acl），请在put_object中设置相关Header。
+        # headers = dict()
+        # headers["x-oss-storage-class"] = "Standard"
+        # headers["x-oss-object-acl"] = oss2.OBJECT_ACL_PRIVATE
+
+        # 填写Object完整路径和字符串。Object完整路径中不能包含Bucket名称。
+        # result = bucket.put_object('exampleobject.txt', 'Hello OSS', headers=headers)
+        result = self.bucket.put_object(filename, data)
+        return result

--- a/oss/upload.py
+++ b/oss/upload.py
@@ -7,6 +7,14 @@ OSS = settings.OSS_CFG
 
 
 class OssOperate:
+    """
+    注意：
+        1. 在阿里云的 RAM 访问控制内，不要给RAM用户授权。
+        否则，在OSS的bucket授权策略将被RAM权限覆盖
+        2. 方案上为了避免外网的直接请求上传，造成流量费用，
+        在OSS的bucket授权策略上，需要明确指定ECS的内网IP
+    """
+
     def __init__(self):
         # 阿里云账号AccessKey拥有所有API的访问权限，风险很高。
         # 强烈建议您创建并使用RAM用户进行API访问或日常运维，请登录RAM控制台创建RAM用户。

--- a/oss/upload.py
+++ b/oss/upload.py
@@ -35,5 +35,12 @@ class OssOperate:
 
         # 填写Object完整路径和字符串。Object完整路径中不能包含Bucket名称。
         # result = bucket.put_object('exampleobject.txt', 'Hello OSS', headers=headers)
-        result = self.bucket.put_object(filename, data)
-        return result
+        try:
+            self.bucket.put_object(filename, data)
+        except aliyunoss.exceptions.OssError as e:
+            rsp = {"code": e.status, "msg": f"{e.code}:{e.message}"}
+        except Exception as e:
+            rsp = {"code": 500, "msg": f"未知错误:{repr(e)}"}
+        else:
+            rsp = {"code": 200, "data": "success"}
+        return rsp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.1.7
-GitPython==3.1.24
+GitPython==3.1.31
 python-frontmatter==1.0.0
 markdown==3.3.6
 Pillow==8.4.0

--- a/tests/test_oss.py
+++ b/tests/test_oss.py
@@ -1,0 +1,18 @@
+import json
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class OssUploadTests(TestCase):
+    def setUp(self) -> None:
+        settings.DEBUG = False
+        self.url = settings.OSS_URL
+
+    def test_upload_ok(self):
+        with open("/home/noinf/图片/上传测试.png", "rb") as file:
+            rsp = self.client.post(self.url, {"name": "aaa.jpg", "file": file})
+            print(rsp.content.decode("utf-8"))
+            self.assertEqual(200, rsp.status_code)
+            retJson = rsp.json()
+            self.assertEqual(200, retJson.get("code"))


### PR DESCRIPTION
### 支持阿里云OSS内网文件上传
使用阿里云oss作为博客的markdown图库。
为了避免OSS使用时的流量费用，利用oss内网访问免费特性，所有图库文件都经过ECS的内网转发。